### PR TITLE
remove angular-polifulls from script tag

### DIFF
--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -1,3 +1,7 @@
+import 'es6-shim';
+import 'reflect-metadata';
+import 'rxjs/Rx';
+import 'zone.js/dist/zone';
 import {bootstrap} from 'angular2/platform/browser';
 import {AppComponent} from './components/app.component';
 

--- a/src/renderer/export.ts
+++ b/src/renderer/export.ts
@@ -1,3 +1,7 @@
+import 'es6-shim';
+import 'reflect-metadata';
+import 'rxjs/Rx';
+import 'zone.js/dist/zone';
 import {bootstrap} from 'angular2/platform/browser';
 import {ExportComponent} from './components/export.component';
 

--- a/src/renderer/export_window.html
+++ b/src/renderer/export_window.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="UTF-8">
     <title>expor to pdf</title>
-    <script src="node_modules/angular2/bundles/angular2-polyfills.js"></script>
     <link rel="stylesheet" href="export.css" type="text/css" />
   </head>
   <body>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="UTF-8">
     <title>Cafe Pitch</title>
-    <script src="node_modules/angular2/bundles/angular2-polyfills.js"></script>
     <link rel="stylesheet" href="app.css" type="text/css" />
   </head>
   <body>

--- a/src/renderer/presentation.ts
+++ b/src/renderer/presentation.ts
@@ -1,3 +1,7 @@
+import 'es6-shim';
+import 'reflect-metadata';
+import 'rxjs/Rx';
+import 'zone.js/dist/zone';
 import {bootstrap} from 'angular2/platform/browser';
 import {PresentationComponent} from './components/presentation.component';
 

--- a/src/renderer/presentation_window.html
+++ b/src/renderer/presentation_window.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="UTF-8">
     <title>Cafe Pitch(presentation)</title>
-    <script src="node_modules/angular2/bundles/angular2-polyfills.js"></script>
     <link rel="stylesheet" href="app.css" type="text/css" />
   </head>
   <body>


### PR DESCRIPTION
If required library is imported on js, so angular-polifulls is unnecessary.
