### PR TITLE
rewrite parent communication of Editor Component

### DIFF
--- a/webpack.config.coffee
+++ b/webpack.config.coffee
@@ -23,5 +23,5 @@ module.exports =
       loader: 'ts-loader'
     ]
   plugins: [
-    new webpack.ExternalsPlugin('commonjs', ['electron', 'fs', 'dialog', 'menu']),
+    new webpack.ExternalsPlugin 'commonjs', ['electron', 'fs', 'dialog', 'menu']
   ]


### PR DESCRIPTION
use @input setter instead of ngOnChanges.
Because I'd like to controll only apllying timing of text value in this case.
